### PR TITLE
Added a file accessibility check to `addFile`

### DIFF
--- a/easy-zip.js
+++ b/easy-zip.js
@@ -21,19 +21,26 @@ function toArrayBuffer(buffer) {
 }
 
 EasyZip.prototype.addFile = function(file,filePath,callback){
-	var datas = [],
-		me = this,
-		rs = fs.createReadStream(filePath);
+	fs.access(filePath, fs.constants.R_OK, function(err) {
+		if (err) {
+			console.error("Easy-zip: Cannot read '%s'", filePath);
+			callback();
+		} else {
+			var datas = [],
+				me = this,
+				rs = fs.createReadStream(filePath);
 
-	rs.on('data',function(data){
-		datas.push(data);
-	})
+			rs.on('data',function(data){
+				datas.push(data);
+			})
 
-	rs.on('end',function(){
-		var buf = Buffer.concat(datas);
-		me.file(file, toArrayBuffer(buf),{base64:false, binary: true});
-		callback();
-	})
+			rs.on('end',function(){
+				var buf = Buffer.concat(datas);
+				me.file(file, toArrayBuffer(buf),{base64:false, binary: true});
+				callback();
+			})
+		}
+	}.bind(this));
 }
 
 EasyZip.prototype.batchAdd = function(files,callback) {


### PR DESCRIPTION
I was back and forth on this idea, as throwing an error has its merits, but since we are adding files within a JSON array, if a file is not accessible, giving a `console.error(..)` prompt and not breaking flows better for me. 

Potentially options can be added so throw exceptions if that is more desired by the end user?